### PR TITLE
Added `loadBase64Data` feature

### DIFF
--- a/ios/Classes/FLPencilKit.swift
+++ b/ios/Classes/FLPencilKit.swift
@@ -131,7 +131,7 @@ class FLPencilKit: NSObject, FlutterPlatformView {
     result: FlutterResult
   ) {
     do {
-      let (base64Data) = parseArguments(call.arguments)
+      let base64Data = call.arguments;
       try pencilKitView.loadBase64Data(base64Data: base64Data)
       result(nil)
     } catch {

--- a/ios/Classes/FLPencilKit.swift
+++ b/ios/Classes/FLPencilKit.swift
@@ -131,7 +131,7 @@ class FLPencilKit: NSObject, FlutterPlatformView {
     result: FlutterResult
   ) {
     do {
-      let base64Data = call.arguments;
+      let base64Data = call.arguments as! String;
       try pencilKitView.loadBase64Data(base64Data: base64Data)
       result(nil)
     } catch {

--- a/ios/Classes/FLPencilKit.swift
+++ b/ios/Classes/FLPencilKit.swift
@@ -132,7 +132,7 @@ class FLPencilKit: NSObject, FlutterPlatformView {
   ) {
     do {
       let (base64Data) = parseArguments(call.arguments)
-      try pencilKitView.load(base64Data: base64Data)
+      try pencilKitView.loadBase64Data(base64Data: base64Data)
       result(nil)
     } catch {
       result(FlutterError(code: "NATIVE_ERROR", message: error.localizedDescription, details: nil))
@@ -260,7 +260,11 @@ private class PencilKitView: UIView {
     return nil
   }
 
-  func load(base64Data: String) throws {
+  func getBase64Data() -> String {
+    canvasView.drawing.dataRepresentation().base64EncodedString()
+  }
+
+  func loadBase64Data(base64Data: String) throws {
     let data = Data(base64Encoded: base64Data)!
     let drawing = try PKDrawing(data: data)
 
@@ -270,10 +274,6 @@ private class PencilKitView: UIView {
     synchronizeCanvasViewProperties(old: canvasView, new: newCanvasView)
     canvasView = newCanvasView
     layoutCanvasView()
-  }
-
-  func getBase64Data() -> String {
-    canvasView.drawing.dataRepresentation().base64EncodedString()
   }
 
   func applyProperties(properties: [String: Any?]) {

--- a/lib/src/pencil_kit.dart
+++ b/lib/src/pencil_kit.dart
@@ -260,5 +260,5 @@ class PencilKitController {
   /// }
   /// ```
   Future<void> loadBase64Data(String base64Data) =>
-      _channel.invokeMethod('loadBase64Data', <Object>[base64Data]);
+      _channel.invokeMethod('loadBase64Data', base64Data);
 }

--- a/lib/src/pencil_kit.dart
+++ b/lib/src/pencil_kit.dart
@@ -245,4 +245,20 @@ class PencilKitController {
   Future<String> getBase64Data() async {
     return await _channel.invokeMethod('getBase64Data') as String;
   }
+
+  /// Load drawing data from base 64 encoded form.
+  /// ```
+  /// Throws an [Error] if failed
+  /// ```
+  /// Example
+  /// ```dart
+  /// try {
+  ///  await controller.loadBase64Data(base64Data);
+  /// // handle success
+  /// } catch (e) {
+  /// // handle error
+  /// }
+  /// ```
+  Future<void> loadBase64Data(String base64Data) =>
+      _channel.invokeMethod('loadBase64Data', <Object>[base64Data]);
 }


### PR DESCRIPTION
I added the `loadBase64Data` feature. So now, it's not limited to save the data to local file system.
You could save the data from `getBase64Data` and save it somewhere else like database.
Then, load the data using `loadBase64Data`.

## Example
```dart
try {
    await controller.loadBase64Data(base64Data);
    // handle success
} catch (e) {
    // handle error
}
```