### PR TITLE
Toggle ios native side touch input enable/disable feature

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -26,6 +26,7 @@ class _MyAppState extends State<MyApp> {
   double currentWidth = 1;
   Color currentColor = Colors.black;
   String base64Image = '';
+  bool isPencilKitEnabled = true;
 
   @override
   Widget build(BuildContext context) {
@@ -34,7 +35,7 @@ class _MyAppState extends State<MyApp> {
           textButtonTheme: const TextButtonThemeData(
             style: ButtonStyle(
               visualDensity: VisualDensity.compact,
-              padding: MaterialStatePropertyAll(
+              padding: WidgetStatePropertyAll(
                 EdgeInsets.all(8),
               ),
             ),
@@ -63,6 +64,13 @@ class _MyAppState extends State<MyApp> {
             IconButton(
               icon: const Icon(Icons.refresh),
               onPressed: () => controller.clear(),
+            ),
+            Switch(
+              value: isPencilKitEnabled,
+              onChanged: (bool value) {
+                setState(() => isPencilKitEnabled = value);
+                controller.setPencilKitEnabled(isPencilKitEnabled);
+              },
             ),
           ],
         ),

--- a/ios/Classes/FLPencilKit.swift
+++ b/ios/Classes/FLPencilKit.swift
@@ -78,6 +78,9 @@ class FLPencilKit: NSObject, FlutterPlatformView {
       case "setPKTool":
         pencilKitView.setPKTool(properties: call.arguments as! [String: Any])
         result(nil)
+      case "setPencilKitEnabled":
+        pencilKitView.setPencilKitEnabled(enabled:call.arguments as! Bool)
+        result(nil)
       case "save":
         save(pencilKitView: pencilKitView, call: call, result: result)
       case "load":
@@ -268,6 +271,10 @@ private class PencilKitView: UIView {
 
   func hide() {
     canvasView.resignFirstResponder()
+  }
+
+  func setPencilKitEnabled(enabled: Bool) {
+    canvasView.isUserInteractionEnabled = enabled
   }
 
   func setPKTool(properties: [String: Any]) {

--- a/lib/src/pencil_kit.dart
+++ b/lib/src/pencil_kit.dart
@@ -78,6 +78,7 @@ class PencilKit extends StatefulWidget {
     this.isRulerActive,
     this.drawingPolicy,
     this.isOpaque,
+    this.isPencilKitEnabled = true,
     this.backgroundColor,
     this.toolPickerVisibilityDidChange,
     this.toolPickerIsRulerActiveDidChange,
@@ -117,6 +118,8 @@ class PencilKit extends StatefulWidget {
   /// If the view is opaque and either does not fill its bounds or contains wholly or partially transparent content, the results are unpredictable.
   /// You should always set the value of this property to false if the view is fully or partially transparent.
   final bool? isOpaque;
+
+  final bool? isPencilKitEnabled;
 
   /// The view’s background color. The default is transparent
   final Color? backgroundColor;
@@ -285,6 +288,9 @@ class PencilKitController {
       'backgroundColor': widget.backgroundColor?.value,
     });
   }
+
+  Future<void> setPencilKitEnabled(bool enable) =>
+      _channel.invokeMethod('setPencilKitEnabled', enable);
 
   /// Clear all drawing data
   Future<void> clear() => _channel.invokeMethod('clear');


### PR DESCRIPTION
<!-- Thank you for contributing `flutter-pencilkit` package 🤗 -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Release (merge into main branch)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## What does this change?

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
<!-- Please delete section if it is not a PR changes feature. -->

Fixes #13 🎯
toggle ios native side touch input enable/disable feature
by setting CanvasView.isUserInteractionEnabled value to true/false 
[please check my comment for detail infos](https://github.com/mym0404/flutter-pencilkit/issues/13#issuecomment-2292962293).
