### PR TITLE
fix: Respect the picker's "Draw with finger" setting by default

### DIFF
--- a/ios/Classes/FLPencilKit.swift
+++ b/ios/Classes/FLPencilKit.swift
@@ -188,7 +188,9 @@ private func createCanvasView(delegate: PKCanvasViewDelegate) -> PKCanvasView {
   v.drawing = PKDrawing()
   v.delegate = delegate
   v.alwaysBounceVertical = false
-  v.allowsFingerDrawing = true
+  if #unavailable(iOS 14.0) {
+    v.allowsFingerDrawing = true
+  }
   v.backgroundColor = .clear
   v.isOpaque = false
   return v


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## What does this change?

Only set `allowsFingerDrawing` for iOS 13, after which it is deprecated.

Setting this option means that the default behavior (when a drawing policy is not provided) is that the tool picker's "Draw with finger" setting (`UIPencilInteraction.prefersPencilOnlyDrawing`) is ignored, contrary to what users would expect.

Fixes #27 🎯